### PR TITLE
Remove appVersion overwrite

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -59,7 +59,6 @@ jobs:
       run: |
         VERSION="${{ steps.version.outputs.version }}"
         sed -i "s/^version:.*/version: $VERSION/" Chart.yaml
-        sed -i "s/^appVersion:.*/appVersion: \"$VERSION\"/" Chart.yaml
 
     - name: Package Helm Chart
       run: |


### PR DESCRIPTION
Hello, `helm-release.yaml` currently not only overwrites the chart version with the intended release version (which is fine), but also the appVersion (which is not fine), as currently the appVersion is out-of-sync with the chart version and needs to be prefixed with a "v" (e.g. `version: "0.17.6"`, `appVersion: "v0.17.4"`), making the helm chart broken by default.

Its is easily possible to work around this by setting `api.image.tag` in `values.yaml` explicitly, but this shouldn't be necessary.

Until the tags of the containers are consistent with the chart version, I'd propose this line be removed.

Thank you for your efforts so far, I'm really liking your project.