### PR TITLE
feat(observability): make the grafana dashboard label configurable

### DIFF
--- a/templates/devguard/grafana-dashboard.yaml
+++ b/templates/devguard/grafana-dashboard.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: devguard-span-metrics
   labels:
-    grafana_dashboard: "1"
+    {{ default "grafana_dashboard" .Values.observability.grafanaDashboard.labelName }}: {{ default "1" .Values.observability.grafanaDashboard.labelValue | quote }}
     {{- include "devguard.labels" . | nindent 4 }}
 data:
   devguard-span-metrics.json: |-

--- a/templates/postgresql/grafana-dashboard.yaml
+++ b/templates/postgresql/grafana-dashboard.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: devguard-postgresql
   labels:
-    grafana_dashboard: "1"
+    {{ default "grafana_dashboard" .Values.observability.grafanaDashboard.labelName }}: {{ default "1" .Values.observability.grafanaDashboard.labelValue | quote }}
     {{- include "devguard.labels" . | nindent 4 }}
 data:
   devguard-postgresql.json: |-

--- a/values.yaml
+++ b/values.yaml
@@ -354,9 +354,15 @@ observability:
     interval: 30s
     scrapeTimeout: 10s
   grafanaDashboard:
-    # Set to true to deploy a Grafana dashboard ConfigMap for span metrics
-    # Requires the Grafana sidecar to watch for ConfigMaps with label grafana_dashboard=1
+    # Set to true to deploy Grafana dashboard ConfigMaps for span metrics and postgresql
+    # Requires the Grafana sidecar to watch for ConfigMaps with the label you can configure below
     enabled: false
+
+    # The label name which the Grafana sidecar is searching for. Defaults to "grafana_dashboard"
+    # labelName: "grafana_dashboard"
+    # The label value which the Grafana sidecar is searching for. Defaults to "1"
+    # labelValue: "1"
+
   api:
     metrics:
       # Path of the metrics endpoint exposed by the DevGuard API


### PR DESCRIPTION
Small improvement to make the Grafana dashboard label configurable, as it can be something else than `grafana_dashboard: "1"`.

Mimics the current behaviour if the new values are missing, to be least invasive.

I did not bump any chart versions, as I think you are changing these during your CI. If that is not the case let me know if I should adjust it.

Cheers