### PR TITLE
feat: allow to specify additional environment variables for all services

### DIFF
--- a/templates/devguard-web/deployment.yaml
+++ b/templates/devguard-web/deployment.yaml
@@ -99,6 +99,10 @@ spec:
           - name: ERROR_TRACKING_DSN
             value: {{ .Values.web.errorTracking.dsn | quote }}
           {{- end }}
+          {{- range $key, $val := .Values.web.additionalEnvs }}
+          - name: {{ $key }}
+            value: {{ tpl $val $ | quote }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 3000

--- a/templates/devguard/deployment.yaml
+++ b/templates/devguard/deployment.yaml
@@ -287,6 +287,10 @@ spec:
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: "grpc://localhost:4317"
         {{- end }}
+        {{- range $key, $val := .Values.api.additionalEnvs }}
+          - name: {{ $key }}
+            value: {{ tpl $val $ | quote }}
+        {{- end }}
           ports:
           - name: http
             containerPort: 8080

--- a/templates/kratos/kratos-deployment.yaml
+++ b/templates/kratos/kratos-deployment.yaml
@@ -134,6 +134,10 @@ spec:
                 name: "{{ $provider.existingClientSecretName }}"
                 key: "secret"
         {{- end }}
+        {{- range $key, $val := .Values.kratos.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ tpl $val $ | quote }}
+        {{- end }}
         ports:
         - name: http-admin
           containerPort: 4434

--- a/templates/postgresql/postgresql-statefulset.yaml
+++ b/templates/postgresql/postgresql-statefulset.yaml
@@ -89,6 +89,10 @@ spec:
             secretKeyRef:
               key: password
               name: kratos-db-secret
+        {{- range $key, $val := .Values.postgresql.additionalEnvs }}
+        - name: {{ $key }}
+          value: {{ tpl $val $ | quote }}
+        {{- end }}
         resources:
           {{- toYaml .Values.postgresql.resources | nindent 10 }}
       {{- if .Values.observability.serviceMonitor.enabled }}

--- a/values.yaml
+++ b/values.yaml
@@ -47,6 +47,17 @@ kratos:
     enabled: true
     # Default: every 10 minutes.
     schedule: "*/10 * * * *"
+
+  # Allows to set additional environment variables on the kratos deployment
+  # Expects "key: value" definitions.
+  # The value is parsed through the `tpl` function, so it allows to reference other values
+  # 
+  # Example:
+  # additionalEnvs:
+  #   TEST_CHART_VERSION: "{{ .Chart.Version }}"
+  #   MY_ENV_VAR: "my-value"
+  additionalEnvs: []
+
 mail:
   # needs to contain key: "uri". Format should be like: smtps://<user>@<your-domain.com>:<secret>@<mail-server.de>:465/?skip_ssl_verify=false
   existingSMTPConnectionUriSecret: ""
@@ -183,6 +194,16 @@ api:
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
+  # Allows to set additional environment variables on the api deployment
+  # Expects "key: value" definitions.
+  # The value is parsed through the `tpl` function, so it allows to reference other values
+  # 
+  # Example:
+  # additionalEnvs:
+  #   TEST_CHART_VERSION: "{{ .Chart.Version }}"
+  #   MY_ENV_VAR: "my-value"
+  additionalEnvs: []
+
 
 ################################################################################################################################################
 ## DevGuard Web Frontend Settings
@@ -220,6 +241,16 @@ web:
   errorTracking:
     # https://<your-error-tracking-dsn>
     dsn: ""
+
+  # Allows to set additional environment variables on the web deployment
+  # Expects "key: value" definitions.
+  # The value is parsed through the `tpl` function, so it allows to reference other values
+  # 
+  # Example:
+  # additionalEnvs:
+  #   TEST_CHART_VERSION: "{{ .Chart.Version }}"
+  #   MY_ENV_VAR: "my-value"
+  additionalEnvs: []
 
   ingress:
     enabled: true
@@ -336,6 +367,16 @@ postgresql:
     requests:
       cpu: 1000m
       memory: 2056Mi
+
+  # Allows to set additional environment variables on the postgresql statefulset
+  # Expects "key: value" definitions.
+  # The value is parsed through the `tpl` function, so it allows to reference other values
+  # 
+  # Example:
+  # additionalEnvs:
+  #   TEST_CHART_VERSION: "{{ .Chart.Version }}"
+  #   MY_ENV_VAR: "my-value"
+  additionalEnvs: []
 
 
 ################################################################################################################################################


### PR DESCRIPTION
Moin moin,

another quick feature PR, to allow to specify additional env vars per service.
I explicitly set the input to "key: value", so that we can run the values through the `tpl` function as well as enforce quotes on it.

regards