### PR TITLE
add PoC for signed charts

### DIFF
--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -41,8 +41,18 @@
 <pre><code>helm repo add devguard __BASE_URL__
 helm repo update
 helm install devguard devguard/devguard</code></pre>
+    <h2>Verifying a chart</h2>
+    <p>
+      Chart packages are signed with OpenPGP; every package is published
+      alongside a <code>.prov</code> provenance file.
+    </p>
+<pre><code>curl -sLO __BASE_URL__/signing-key.asc
+gpg --dearmor &lt; signing-key.asc &gt; signing-key.gpg
+helm pull devguard/devguard --prov
+helm verify devguard-*.tgz --keyring ./signing-key.gpg</code></pre>
     <p>
       <a href="__BASE_URL__/index.yaml">index.yaml</a> ·
+      <a href="__BASE_URL__/signing-key.asc">signing key</a> ·
       <a href="https://github.com/l3montree-dev/devguard-helm-chart">Source</a> ·
       <a href="https://docs.devguard.org">Documentation</a>
     </p>

--- a/.github/workflows/helm-pages.yml
+++ b/.github/workflows/helm-pages.yml
@@ -3,10 +3,13 @@ name: Publish Helm Repository
 # Publishes a classic (HTTP) Helm repository to GitHub Pages.
 #
 # The site is rebuilt from scratch on every run: all `*.tgz` chart packages
-# attached to the GitHub releases are downloaded, `helm repo index` generates
-# the `index.yaml`, and `artifacthub-repo.yml` is copied next to it so
-# artifacthub.io can pick up the repository metadata (ownership claim /
-# verified publisher).
+# attached to the GitHub releases are downloaded together with their `*.prov`
+# provenance files, `helm repo index` generates the `index.yaml`, and
+# `artifacthub-repo.yml` is copied next to it so artifacthub.io can pick up the
+# repository metadata (ownership claim / verified publisher).
+#
+# The provenance files must be served as `<chart-url>.prov` — that is exactly
+# where `helm verify` and Artifact Hub's "signed" badge look for them.
 #
 # Requires Pages to be enabled with "GitHub Actions" as the build source
 # (Settings → Pages → Build and deployment → Source: GitHub Actions).
@@ -36,6 +39,9 @@ env:
   # them from `helm install`/`helm search` unless `--devel` is passed, but they
   # do show up on Artifact Hub.
   INCLUDE_PRERELEASES: 'false'
+  # Public half of the chart signing key. Kept in sync with helm-release.yml,
+  # which signs the packages with the private half.
+  PUBLIC_KEY: .github/pages/signing-key.asc
 
 # Never let two deployments race for the single Pages environment.
 concurrency:
@@ -105,7 +111,9 @@ jobs:
               continue
             fi
 
-            if gh release download "$TAG" --pattern '*.tgz' --dir site --skip-existing; then
+            # Releases made before chart signing was introduced have no *.prov
+            # asset; gh only fails when neither pattern matches anything.
+            if gh release download "$TAG" --pattern '*.tgz' --pattern '*.tgz.prov' --dir site --skip-existing; then
               echo "Downloaded chart package(s) for $TAG"
             else
               echo "::notice::Release $TAG has no chart package attached — skipping"
@@ -120,6 +128,42 @@ jobs:
           if [ "$COUNT" -eq 0 ]; then
             echo "::error::No chart packages found in any release — refusing to publish an empty repository."
             exit 1
+          fi
+
+      # Guards against publishing a provenance file that nobody can verify —
+      # e.g. after the signing key was rotated but the committed public half
+      # was not.
+      - name: Verify chart signatures
+        run: |
+          set -euo pipefail
+          if [ ! -f "$PUBLIC_KEY" ]; then
+            echo "::warning::$PUBLIC_KEY is missing — skipping signature verification."
+            exit 0
+          fi
+          gpg --dearmor < "$PUBLIC_KEY" > "$RUNNER_TEMP/pubring.gpg"
+
+          SIGNED=0
+          UNSIGNED=0
+          for CHART in site/*.tgz; do
+            if [ -f "$CHART.prov" ]; then
+              helm verify "$CHART" --keyring "$RUNNER_TEMP/pubring.gpg"
+              SIGNED=$((SIGNED + 1))
+            else
+              echo "::notice::$(basename "$CHART") has no provenance file — released before chart signing was introduced."
+              UNSIGNED=$((UNSIGNED + 1))
+            fi
+          done
+          echo "$SIGNED signed, $UNSIGNED unsigned chart package(s)"
+
+      # Served at <pages-url>/signing-key.asc, which is the URL advertised in the
+      # chart's `artifacthub.io/signKey` annotation.
+      - name: Publish the signing public key
+        run: |
+          set -euo pipefail
+          if [ -f "$PUBLIC_KEY" ]; then
+            cp "$PUBLIC_KEY" site/signing-key.asc
+          else
+            echo "::warning::$PUBLIC_KEY is missing — users have no key to verify chart signatures against."
           fi
 
       - name: Generate Helm repository index

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -15,6 +15,12 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  # Public half of the chart signing key, committed to the repo. helm-pages.yml
+  # publishes it next to index.yaml so users can run `helm verify` themselves.
+  PUBLIC_KEY: .github/pages/signing-key.asc
+  # Where that key ends up once helm-pages.yml has run. Announced to users via
+  # the `artifacthub.io/signKey` annotation.
+  SIGN_KEY_URL: https://l3montree-dev.github.io/devguard-helm-chart/signing-key.asc
 
 jobs:
   release:
@@ -41,6 +47,63 @@ jobs:
       with:
         version: '3.19.0'
 
+    # Signing produces a `<chart>.tgz.prov` provenance file next to the package.
+    # That file is what `helm verify` checks and what Artifact Hub looks for to
+    # show the "signed" badge (it probes `<chart-url>.prov` for HTTP repos and
+    # the provenance layer for OCI ones).
+    #
+    # Helm signs with a legacy binary keyring, which gpg >= 2.1 no longer keeps
+    # on disk, so the exported keyring is stored base64-encoded in the
+    # GPG_KEYRING_BASE64 secret. See DISTRIBUTION.md → "Chart signing".
+    - name: Prepare chart signing key
+      id: signing
+      env:
+        GPG_KEYRING_BASE64: ${{ secrets.GPG_KEYRING_BASE64 }}
+        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        # Optional escape hatch: Helm matches --key against the full OpenPGP
+        # user ID, which is normally derived from the public key below.
+        KEY_UID_OVERRIDE: ${{ vars.GPG_KEY_UID }}
+      run: |
+        set -euo pipefail
+
+        MISSING=""
+        [ -n "$GPG_KEYRING_BASE64" ] || MISSING="the GPG_KEYRING_BASE64 secret"
+        [ -f "$PUBLIC_KEY" ] || MISSING="${MISSING:+$MISSING and }$PUBLIC_KEY"
+
+        if [ -n "$MISSING" ]; then
+          # Never ship a tagged release unsigned — that is the one users install.
+          if [ "$GITHUB_REF" != "${GITHUB_REF#refs/tags/}" ]; then
+            echo "::error::Missing $MISSING — refusing to publish an unsigned tagged release."
+            exit 1
+          fi
+          echo "::warning::Missing $MISSING — packaging without a provenance file."
+          echo "sign=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        printf '%s' "$GPG_KEYRING_BASE64" | base64 -d > "$RUNNER_TEMP/secring.gpg"
+        # Trailing newline on purpose: helm reads the first line of this file, and
+        # an entirely empty file makes it error out instead of using no passphrase.
+        printf '%s\n' "$GPG_PASSPHRASE" > "$RUNNER_TEMP/passphrase"
+        chmod 600 "$RUNNER_TEMP/secring.gpg" "$RUNNER_TEMP/passphrase"
+
+        # `helm verify` wants the same binary format for the public keyring.
+        gpg --dearmor < "$PUBLIC_KEY" > "$RUNNER_TEMP/pubring.gpg"
+
+        FINGERPRINT=$(gpg --batch --with-colons --show-keys "$PUBLIC_KEY" | awk -F: '/^fpr:/ { print $10; exit }')
+        KEY_UID=${KEY_UID_OVERRIDE:-$(gpg --batch --with-colons --show-keys "$PUBLIC_KEY" | awk -F: '/^uid:/ { print $10; exit }')}
+        if [ -z "$FINGERPRINT" ] || [ -z "$KEY_UID" ]; then
+          echo "::error::Could not read a fingerprint and user ID from $PUBLIC_KEY"
+          exit 1
+        fi
+
+        echo "Signing as: $KEY_UID ($FINGERPRINT)"
+        {
+          echo "sign=true"
+          echo "fingerprint=$FINGERPRINT"
+          echo "key_uid=$KEY_UID"
+        } >> "$GITHUB_OUTPUT"
+
     - name: Log in to GitHub Container Registry
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -64,12 +127,47 @@ jobs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "Releasing version: $VERSION"
 
+    # Purely informational on Artifact Hub — the "signed" badge comes from the
+    # provenance file, not from this annotation. What it buys is a discoverable
+    # key: without it nobody knows what to verify the signature against.
+    - name: Annotate Chart.yaml with the signing key
+      if: steps.signing.outputs.sign == 'true'
+      env:
+        FINGERPRINT: ${{ steps.signing.outputs.fingerprint }}
+      run: |
+        set -euo pipefail
+        SIGN_KEY=$(printf 'fingerprint: %s\nurl: %s\n' "$FINGERPRINT" "$SIGN_KEY_URL")
+        SIGN_KEY="$SIGN_KEY" yq -i '.annotations["artifacthub.io/signKey"] = strenv(SIGN_KEY)' Chart.yaml
+        yq '.annotations' Chart.yaml
+
     - name: Package Helm Chart
       env:
         VERSION: ${{ steps.version.outputs.version }}
+        SIGN: ${{ steps.signing.outputs.sign }}
+        KEY_UID: ${{ steps.signing.outputs.key_uid }}
       run: |
+        set -euo pipefail
         helm dependency update
-        helm package . --version "$VERSION" --destination ./charts/
+        if [ "$SIGN" = "true" ]; then
+          # Also writes ./charts/devguard-$VERSION.tgz.prov
+          helm package . --version "$VERSION" --destination ./charts/ \
+            --sign --key "$KEY_UID" \
+            --keyring "$RUNNER_TEMP/secring.gpg" \
+            --passphrase-file "$RUNNER_TEMP/passphrase"
+        else
+          helm package . --version "$VERSION" --destination ./charts/
+        fi
+        ls -l ./charts/
+
+    # Catches a keyring whose public half is not the committed one — otherwise
+    # the release would carry a provenance file nobody can verify.
+    - name: Verify chart signature
+      if: steps.signing.outputs.sign == 'true'
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
+      run: |
+        set -euo pipefail
+        helm verify "./charts/devguard-$VERSION.tgz" --keyring "$RUNNER_TEMP/pubring.gpg"
 
     - name: Push Helm Chart to GitHub Container Registry
       env:
@@ -77,6 +175,8 @@ jobs:
       run: |
         CHART_PACKAGE="devguard-$VERSION.tgz"
         echo "Pushing chart: $CHART_PACKAGE to oci://$REGISTRY/$GITHUB_REPOSITORY"
+        # helm push uploads $CHART_PACKAGE.prov as an OCI provenance layer
+        # automatically whenever it sits next to the package.
         helm push "./charts/$CHART_PACKAGE" "oci://$REGISTRY/$GITHUB_REPOSITORY"
 
     - name: Get minor version
@@ -110,6 +210,16 @@ jobs:
           helm pull oci://ghcr.io/${{ github.repository }}/devguard --version ${{ steps.version.outputs.version }}
           ```
 
+          ## Verify
+
+          The chart package is signed; `devguard-${{ steps.version.outputs.version }}.tgz.prov` is attached below.
+
+          ```bash
+          curl -sLO ${{ env.SIGN_KEY_URL }}
+          gpg --dearmor < signing-key.asc > signing-key.gpg
+          helm verify devguard-${{ steps.version.outputs.version }}.tgz --keyring ./signing-key.gpg
+          ```
+
           ---
 
           ## Versioning
@@ -132,7 +242,13 @@ jobs:
           *-rc*|*-alpha*|*-beta*) PRERELEASE="--prerelease" ;;
         esac
 
-        gh release create "$TAG" charts/*.tgz \
+        # The .prov file has to be a release asset too: helm-pages.yml rebuilds
+        # the HTTP repository from the release assets, and Artifact Hub only
+        # sees a chart as signed if <chart-url>.prov is served next to it.
+        shopt -s nullglob
+        ASSETS=(charts/*.tgz charts/*.tgz.prov)
+
+        gh release create "$TAG" "${ASSETS[@]}" \
           --title "$TAG" \
           --notes-file "$RUNNER_TEMP/release-notes.md" \
           --generate-notes \

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -45,9 +45,10 @@ Besides the OCI registry, the chart is published as a classic HTTP Helm reposito
 The workflow (`.github/workflows/helm-pages.yml`):
 
 - **Triggers on**: a completed tag release (called by `helm-release.yml`), a push to `main` touching `artifacthub-repo.yml` or the landing page, or manual dispatch
-- **Collects**: every `*.tgz` chart package attached to the GitHub releases
+- **Collects**: every `*.tgz` chart package and `*.tgz.prov` provenance file attached to the GitHub releases
+- **Verifies**: every collected package against the committed public key before publishing
 - **Generates**: `index.yaml` via `helm repo index --url <pages-url>`
-- **Publishes**: `index.yaml`, all chart packages, `artifacthub-repo.yml` and a landing page to GitHub Pages
+- **Publishes**: `index.yaml`, all chart packages and provenance files, `signing-key.asc`, `artifacthub-repo.yml` and a landing page to GitHub Pages
 
 The site is rebuilt from scratch on every run — the GitHub releases are the source of truth.
 
@@ -64,6 +65,99 @@ helm install devguard devguard/devguard
 `artifacthub-repo.yml` is copied next to `index.yaml` so [artifacthub.io](https://artifacthub.io) can read the repository metadata — this is what enables the ownership claim and the verified publisher flag. Set `repositoryID` in that file to the ID of the Artifact Hub repository to activate the verified publisher badge.
 
 Note that Artifact Hub only reprocesses an HTTP Helm repository when `index.yaml` changes.
+
+## Chart signing
+
+Every released chart package is signed with OpenPGP, producing a `<chart>.tgz.prov`
+provenance file next to it. That file is what `helm verify` checks, and it is also
+what makes Artifact Hub show the **signed** badge — it probes `<chart-url>.prov` for
+HTTP repositories and the `application/vnd.cncf.helm.chart.provenance.v1.prov` layer
+for OCI ones. Note that Artifact Hub only checks that the file *exists* and looks
+like a PGP signature; it does not validate it. The `artifacthub.io/signKey`
+annotation does not affect the badge, it only tells users which key to verify against.
+
+### One-time setup
+
+1. Create a signing key (no expiry is fine for a chart signing key, but rotation is easier with one):
+
+   ```bash
+   gpg --quick-generate-key "DevGuard Chart Signing <info@l3montree.com>" rsa4096 sign 2y
+   ```
+
+2. Commit the public half — it is both the verification key for users and the source
+   of the fingerprint and user ID that CI uses:
+
+   ```bash
+   gpg --armor --export "DevGuard Chart Signing" > .github/pages/signing-key.asc
+   ```
+
+3. Export the secret keyring. Helm signs with the legacy binary keyring format,
+   which gpg ≥ 2.1 no longer keeps on disk, so it has to be exported explicitly:
+
+   ```bash
+   gpg --export-secret-keys "DevGuard Chart Signing" | base64 | tr -d '\n' | pbcopy
+   ```
+
+4. Add the repository secrets (Settings → Secrets and variables → Actions):
+
+   | Secret | Contents |
+   | --- | --- |
+   | `GPG_KEYRING_BASE64` | output of step 3 |
+   | `GPG_PASSPHRASE` | passphrase of the key (leave unset if the key has none) |
+
+   Optionally set the `GPG_KEY_UID` **variable** if Helm's `--key` should match
+   something other than the first user ID of the committed public key.
+
+5. Verify the round trip locally before tagging a release:
+
+   ```bash
+   gpg --export-secret-keys "DevGuard Chart Signing" > /tmp/secring.gpg
+   gpg --dearmor < .github/pages/signing-key.asc > /tmp/pubring.gpg
+
+   helm package . --sign --key "DevGuard Chart Signing" --keyring /tmp/secring.gpg
+   helm verify devguard-*.tgz --keyring /tmp/pubring.gpg
+   ```
+
+   Both `--keyring` flags need the *binary* keyring format — Helm reads it with
+   `openpgp.ReadKeyRing`, which does not understand ASCII armor.
+
+### What the release workflow does
+
+`helm-release.yml` restores the keyring, injects `artifacthub.io/signKey`
+(fingerprint plus the Pages URL of the public key) into `Chart.yaml`, packages with
+`--sign`, verifies the result against the committed public key, and attaches both
+the `.tgz` and the `.tgz.prov` to the GitHub release. `helm push` picks up the
+provenance file automatically and uploads it as an OCI layer.
+
+A **tagged** release fails hard if the keyring secret or the public key is missing —
+the versions users actually install must never go out unsigned. Pushes to `main`
+(the `0.0.0-main` package) only warn and publish unsigned.
+
+### Verifying as a user
+
+```bash
+curl -sLO https://l3montree-dev.github.io/devguard-helm-chart/signing-key.asc
+gpg --dearmor < signing-key.asc > signing-key.gpg
+
+helm pull devguard/devguard --prov          # HTTP repository
+helm pull oci://ghcr.io/l3montree-dev/devguard-helm-chart/devguard --prov   # OCI
+
+helm verify devguard-*.tgz --keyring ./signing-key.gpg
+```
+
+`helm install --verify` does the same check inline, provided the keyring is in place.
+
+### Rotation
+
+Replace `.github/pages/signing-key.asc` and `GPG_KEYRING_BASE64` together. The Pages
+job re-verifies *all* published packages on every run, so a mismatch between the
+committed public key and the packages already released fails the deployment rather
+than silently publishing unverifiable provenance files. Keep the old public key
+appended to `signing-key.asc` (it is a keyring — it can hold several keys) so
+previously released versions stay verifiable.
+
+> Signing is not wired into `.gitlab-ci.yml`. The GitLab pipeline is a mirror and is
+> not indexed by Artifact Hub; adding it needs the same two variables in GitLab CI/CD.
 
 ## GitLab CI Pipeline
 


### PR DESCRIPTION
## Sign chart packages (provenance files)

Releases now ship an OpenPGP-signed `.tgz.prov` next to every chart package, so
`helm verify` works and Artifact Hub shows the "signed" badge (it probes
`<chart-url>.prov` for HTTP repos and the provenance layer for OCI ones).

### Changes

- **helm-release.yml** — restores the signing keyring from `GPG_KEYRING_BASE64`,
  packages with `--sign`, verifies the result against the committed public key,
  and attaches the `.prov` to the GitHub release. `helm push` picks it up as an
  OCI provenance layer automatically. The `artifacthub.io/signKey` annotation is
  injected at package time from the key actually used, so it cannot drift.
- **helm-pages.yml** — collects `*.tgz.prov` alongside the packages, verifies every
  signed package before deploying, and publishes `signing-key.asc` next to
  `index.yaml`.
- **Chart.yaml** — `artifacthub.io/category` was a top-level key, which Helm silently
  drops; moved under `annotations:` so it reaches Artifact Hub.
- Verification instructions on the Pages landing page, in the release notes, and in
  `DISTRIBUTION.md` (key generation, secrets, rotation).

### Required before the next tag

A tagged release now **fails** if signing material is missing (pushes to `main` only
warn):

1. Commit the armored public key to `.github/pages/signing-key.asc`.
2. Add the `GPG_KEYRING_BASE64` and `GPG_PASSPHRASE` secrets — see
   `DISTRIBUTION.md` → "Chart signing".

Charts released before this change stay unsigned and are skipped during verification.
`.gitlab-ci.yml` is unchanged; the GitLab pipeline is a mirror and is not indexed by
Artifact Hub.